### PR TITLE
Telegram Markdown support + Updated content parsing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,8 @@
 {
   "editor.formatOnSave": true,
-  "editor.codeActionsOnSave": { "source.fixAll": true },
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
   "deno.enable": true,
   "deno.lint": true,
-  "deno.suggest.imports.hosts": {
-    "https://deno.land": true
-  }
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,7 @@
 export {
   DOMParser,
   Element,
-} from "https://deno.land/x/deno_dom/deno-dom-wasm.ts";
+} from "https://deno.land/x/deno_dom@v0.1.21-alpha/deno-dom-wasm.ts";
 export { marky } from "https://deno.land/x/marky@v1.1.6/mod.ts";
 export type { Parser } from "https://deno.land/x/marky@v1.1.6/parsers.ts";
+export * as blockParsers from "https://deno.land/x/marky@v1.1.6/parsers.ts";

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -20,8 +20,6 @@ const REGEX = {
     /^.*(?:(?:youtu\.be\/|v\/|vi\/|u\/\w\/|embed\/)|(?:(?:watch)?\?v(?:i)?=|\&v(?:i)?=))([^#\&\?]+).*/,
 } as const;
 
-type ParseMode = "TGMarkdown" | "Markdown" | "HTML";
-
 /**
  * Parses the given HTML or markdown content and returns a Telegra.ph compatible
  * `content` value. You have to provide a `parseMode` in order to parse the
@@ -30,16 +28,17 @@ type ParseMode = "TGMarkdown" | "Markdown" | "HTML";
  */
 export function parse(
   content: string,
-  parseMode: ParseMode,
+  parseMode: "TGMarkdown" | "Markdown" | "HTML",
   markyParsers: Parser[] = [],
 ): string | Node[] {
+  const parsers: Parser[] = [...markyParsers];
   switch (parseMode) {
     case "TGMarkdown": {
-      const md = marky(content, tgMdParsers.concat(markyParsers));
-      return parseHtml(md);
+      const tgMd = marky(content, parsers.concat(tgMdParsers));
+      return parseHtml(tgMd);
     }
     case "Markdown": {
-      const md = marky(content, MdParsers.concat(markyParsers));
+      const md = marky(content, parsers.concat(MdParsers));
       return parseHtml(md);
     }
     case "HTML": {

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -1,0 +1,143 @@
+import { blockParsers as p, Parser } from "../deps.ts";
+
+// Underline, because it is not supported by marky's default parser.
+const underline = (block: string): string =>
+  matchAndReplace(block, "__", 2, "u");
+
+// Follows Telegram Markdown V2 specification.
+// https://core.telegram.org/bots/api#markdownv2-style
+const tgBold = (block: string): string => matchAndReplace(block, "\\*", 1, "b");
+const tgItalic = (block: string): string => matchAndReplace(block, "_", 1, "i");
+const tgStrikethrough = (block: string): string =>
+  matchAndReplace(block, "~", 1, "s");
+
+function matchAndReplace(
+  block: string,
+  matcher: string,
+  length: number,
+  replaceTag: string,
+): string {
+  // Support to escape the matcher.
+  const regex = new RegExp(
+    `${matcher}(.*?)((?<!\\\\)|(?<=\\\\\\\\)|(.+))${matcher}`,
+    "g",
+  );
+  const matches = block.match(regex);
+  if (!matches) return block;
+  for (const match of matches) {
+    const value = match.substring(length, match.length - length);
+    const replacement = `<${replaceTag}>${value}</${replaceTag}>`;
+    block = block.replace(match, replacement);
+  }
+  return block;
+}
+
+// Telegram Markdown V2 parsers.
+export const tgMdParsers: Parser[] = [
+  {
+    matcher: p.isEmptyBlock,
+    renderers: [p.emptyBlock],
+  },
+  {
+    matcher: p.isHeadingBlock,
+    renderers: [
+      underline,
+      tgItalic,
+      tgBold,
+      p.inlineCode,
+      tgStrikethrough,
+      p.linkAndImage,
+      p.headingBlock,
+    ],
+  },
+  {
+    matcher: p.isCodeBlock,
+    renderers: [p.codeBlock],
+  },
+  {
+    matcher: p.isHorizontalLineBlock,
+    renderers: [p.horizontalLineBlock],
+  },
+  {
+    matcher: p.isQuoteBlock,
+    renderers: [p.quoteBlock],
+  },
+  {
+    matcher: p.isListBlock,
+    renderers: [
+      underline,
+      tgItalic,
+      tgBold,
+      p.inlineCode,
+      tgStrikethrough,
+      p.linkAndImage,
+      p.listBlock,
+    ],
+  },
+  {
+    renderers: [
+      underline,
+      tgItalic,
+      tgBold,
+      p.inlineCode,
+      tgStrikethrough,
+      p.linkAndImage,
+      p.paragraphBlock,
+    ],
+  },
+];
+
+// Modified default marky parser.
+export const MdParsers: Parser[] = [
+  {
+    matcher: p.isEmptyBlock,
+    renderers: [p.emptyBlock],
+  },
+  {
+    matcher: p.isHeadingBlock,
+    renderers: [
+      p.bold,
+      p.strikethrough,
+      underline,
+      p.italic,
+      p.inlineCode,
+      p.linkAndImage,
+      p.headingBlock,
+    ],
+  },
+  {
+    matcher: p.isCodeBlock,
+    renderers: [p.codeBlock],
+  },
+  {
+    matcher: p.isHorizontalLineBlock,
+    renderers: [p.horizontalLineBlock],
+  },
+  {
+    matcher: p.isQuoteBlock,
+    renderers: [p.quoteBlock],
+  },
+  {
+    matcher: p.isListBlock,
+    renderers: [
+      p.bold,
+      underline,
+      p.strikethrough,
+      p.italic,
+      p.inlineCode,
+      p.linkAndImage,
+      p.listBlock,
+    ],
+  },
+  {
+    renderers: [
+      p.bold,
+      underline,
+      p.italic,
+      p.inlineCode,
+      p.strikethrough,
+      p.linkAndImage,
+      p.paragraphBlock,
+    ],
+  },
+];

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -32,6 +32,10 @@ function matchAndReplace(
   return block;
 }
 
+// Converts single newlines to spaces.
+const lineBreakParser = (content: string) =>
+  content.replace(/(?!\n\n)(?<!\n)\n/g, " ");
+
 // Telegram Markdown V2 parsers.
 export const tgMdParsers: Parser[] = [
   {
@@ -138,6 +142,7 @@ export const MdParsers: Parser[] = [
       p.strikethrough,
       p.linkAndImage,
       p.paragraphBlock,
+      lineBreakParser,
     ],
   },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,4 @@
-// Available Types
-// https://telegra.ph/api#Available-types
+// Available Types https://telegra.ph/api#Available-types
 export interface Account {
   short_name: string;
   author_name: string;


### PR DESCRIPTION
## Changelog
### Telegram Flavored Markdown support
Closes #1
- Removed [`parseMarkdown`](https://github.com/dcdunkan/telegraph/blob/d8832923a12d62ab76091ba91ecb0d3262a140ef/src/parse.ts#L35).
- Not exporting `parseHtml` anymore.
- Added a common `parse` function which takes in `content` and `parseMode` as arguments, and returns a Telegra.ph compatible `content`. [A full example](https://gist.github.com/dcdunkan/f3939b429ce783d524544b1abebfb69b) (You may have to change the imports since it's not released yet)
 ```ts
const mdContent = parse("**bold**", "Markdown");
const tgMdContent = parse("*bold*", "TGMarkdown"); // MarkdownV2
const htmlContent = parse("<b>bold</b>", "HTML");
```

### Other 
- Formatted comments for better readability (Max 80 characters per line).

I have tried my best on Telegram Markdown support. There could be bugs.

## TODO
- As mentioned in #2, need to update docs. Only releasing after updating both JSDocs and README Docs. And it is currently being updated.